### PR TITLE
Eliminate New Sphinx-Docs Build Error

### DIFF
--- a/docs/Parameters.rst
+++ b/docs/Parameters.rst
@@ -2,7 +2,6 @@
 Parameters
 ----------
 
------
 
 servers
 -------


### PR DESCRIPTION
This change eliminates an error that was occurring in the Sphinx documentation build by removing a horizontal rule.