### PR TITLE
Add option to deploy a custom Prometheus instance

### DIFF
--- a/.github/workflows/ci-github-cms.yaml
+++ b/.github/workflows/ci-github-cms.yaml
@@ -62,6 +62,10 @@ jobs:
         run: |
           kubectl wait --for condition=Ready pod -l app.kubernetes.io/component=envoy --timeout 120s -n cms
 
+      - name: Prometheus ready
+        run: |
+          kubectl wait --for condition=Ready pod -l app.kubernetes.io/component=prometheus --timeout 120s -n cms
+
       - name: Triton server ready
         run: |  
           kubectl wait --for condition=Ready pod -l app.kubernetes.io/component=triton --timeout 300s -n cms
@@ -69,8 +73,7 @@ jobs:
       - name: Autoscaler ready
         run: |
           kubectl wait --for condition=AbleToScale hpa -l app.kubernetes.io/component=keda --timeout 120s -n cms
-          # Don't check for KEDA ScaledObject readinness - it needs Prometheus to be running.
-          # kubectl wait --for condition=Ready so -l app.kubernetes.io/component=keda --timeout 120s -n cms
+          kubectl wait --for condition=Ready so -l app.kubernetes.io/component=keda --timeout 120s -n cms
 
       - name: Validate Deployment
         run: |

--- a/docs/.values-table.md
+++ b/docs/.values-table.md
@@ -47,11 +47,13 @@
 | autoscaler.scaleDown.window | int | `600` |  |
 | autoscaler.scaleDown.period | int | `120` |  |
 | autoscaler.scaleDown.stepsize | int | `1` |  |
-| prometheus | object | `{"port":443,"scheme":"https","serverLoadMetric":"","serverLoadThreshold":100,"url":""}` | Connection to a Prometheus server is required for KEDA autoscaler and Envoy's prometheus-based rate limiter |
-| prometheus.url | string | `""` | Prometheus server url and port number (find in documentation of a given cluster or ask admins) |
-| prometheus.scheme | string | `"https"` | Specify whether Prometheus endpoint is exposed as http or https |
+| prometheus | object | `{"external":true,"ingress":{"annotations":{},"enabled":false,"hostName":"","ingressClassName":""},"port":443,"scheme":"https","serverLoadMetric":"","serverLoadThreshold":100,"url":""}` | Connection to a Prometheus server is required for KEDA autoscaler and Envoy's prometheus-based rate limiter |
+| prometheus.external | bool | `true` | Whether to use external Prometheus instance (true) or deploy internal one (false) |
+| prometheus.url | string | `""` | External Prometheus server url and port number (find in documentation of a given cluster or ask admins) Only used when external=true |
+| prometheus.scheme | string | `"https"` | Specify whether external Prometheus endpoint is exposed as http or https Only used when external=true |
 | prometheus.serverLoadMetric | string | `""` | A metric used by both KEDA autoscaler and Envoy's prometheus-based rate limiter. # Default metric (inference queue latency) is defined in templates/_helpers.tpl |
 | prometheus.serverLoadThreshold | int | `100` | Threshold for the metric |
+| prometheus.ingress | object | `{"annotations":{},"enabled":false,"hostName":"","ingressClassName":""}` | Ingress configuration for internal Prometheus web UI (only used when external=false) |
 | ingress.enabled | bool | `false` |  |
 | ingress.hostName | string | `""` |  |
 | ingress.ingressClassName | string | `""` |  |

--- a/helm/supersonic/templates/NOTES.txt
+++ b/helm/supersonic/templates/NOTES.txt
@@ -8,13 +8,13 @@
 
 SuperSONIC chart successfully installed!
 
-┌----------------------------------------------------------------------------─┐
+┌-----------------------------------------------------------------------------┐
 | Chart name: {{ .Chart.Name }}
 | Version: {{ .Chart.Version }}
 | Release name: {{ .Release.Name }}
 | Instance name *: {{ (include "supersonic.name" .) }}
 | * equal to release name, unless nameOverride is specified.
-└----------------------------------------------------------------------------─┘
+└-----------------------------------------------------------------------------┘
 ┌-----------------------------------------------------------------------------┐
 | Documentation:           https://fastmachinelearning.org/SuperSONIC
 |

--- a/helm/supersonic/templates/NOTES.txt
+++ b/helm/supersonic/templates/NOTES.txt
@@ -1,4 +1,3 @@
-
 ---
 
    ____                  ___  ___  _  _ ___ ___ 
@@ -7,25 +6,25 @@
 /___/\_,_/ .__/\__/_/   |___/\___/|_|\_|___\___|
         /_/                                      
 
-https://fastmachinelearning.org/SuperSONIC
-
 SuperSONIC chart successfully installed!
 
-  Chart name: {{ .Chart.Name }}
-  Release name: {{ .Release.Name }}
-  Instance name *: {{ (include "supersonic.name" .) }}
-  * equal to release name, unless nameOverride is specified.
-
-Uninstall as follows:
-
-  helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}
-
+┌----------------------------------------------------------------------------─┐
+| Chart name: {{ .Chart.Name }}
+| Version: {{ .Chart.Version }}
+| Release name: {{ .Release.Name }}
+| Instance name *: {{ (include "supersonic.name" .) }}
+| * equal to release name, unless nameOverride is specified.
+└----------------------------------------------------------------------------─┘
+┌-----------------------------------------------------------------------------┐
+| Documentation:           https://fastmachinelearning.org/SuperSONIC
+|
+| Uninstall:               helm uninstall {{ .Release.Name }} -n {{ .Release.Namespace }}
+|
 {{- if .Values.ingress.enabled }}
-
-Once the Triton servers are running, you can send inference requests to the following address:
-
-  {{ .Values.ingress.hostName }}:443
-
+| gRPC endpoint:           {{ .Values.ingress.hostName }}:443
 {{- end }}
-
----
+|
+{{- if (not .Values.prometheus.external) }}
+| Prometheus UI:           https://{{ .Values.prometheus.ingress.hostName }}
+{{- end }}
+└-----------------------------------------------------------------------------┘

--- a/helm/supersonic/templates/_helpers.tpl
+++ b/helm/supersonic/templates/_helpers.tpl
@@ -15,6 +15,10 @@
 {{- printf "%s-envoy" (include "supersonic.name" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
+{{- define "supersonic.prometheusName" -}}
+{{- printf "%s-prometheus" (include "supersonic.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 {{- define "supersonic.defaultMetric" -}}
 {{- if not ( eq .Values.prometheus.serverLoadMetric "" ) }}
   {{- printf "%s" .Values.prometheus.serverLoadMetric -}}

--- a/helm/supersonic/templates/envoy-configmaps.yaml
+++ b/helm/supersonic/templates/envoy-configmaps.yaml
@@ -97,9 +97,14 @@ static_resources:
               - endpoint:
                   address:
                     socket_address:
+                      {{- if $.prometheus.external }}
                       address: {{ $.prometheus.url }}
                       port_value: {{ $.prometheus.port }}
-      {{- if eq $.prometheus.scheme "https" }}
+                      {{- else }}
+                      address: {{ printf "%s-prometheus.%s.svc.cluster.local" (include "supersonic.name" $.root) $.root.Release.Namespace }}
+                      port_value: 9090
+                      {{- end }}
+      {{- if and $.prometheus.external (eq $.prometheus.scheme "https") }}
       transport_socket:
         name: envoy.transport_sockets.tls
         typed_config:
@@ -176,6 +181,7 @@ static_resources:
     "envoy" .Values.envoy
     "triton" .Values.triton
     "tritonName" $tritonName
+    "root" .
 }}
 
 apiVersion: v1
@@ -207,8 +213,13 @@ data:
     {{- $luaConfig := $.Files.Get .Values.envoy.rate_limiter.prometheus_based.luaConfig | nindent 4 }}
     {{- $luaConfig = $luaConfig | replace "SERVER_LOAD_METRIC" (include "supersonic.defaultMetric" . | quote) }}
     {{- $luaConfig = $luaConfig | replace "SERVER_LOAD_THRESHOLD" (quote .Values.prometheus.serverLoadThreshold) }}
+    {{- if .Values.prometheus.external }}
     {{- $luaConfig = $luaConfig | replace "PROMETHEUS_URL" .Values.prometheus.url }}
     {{- $luaConfig = $luaConfig | replace "PROMETHEUS_SCHEME" .Values.prometheus.scheme }}
+    {{- else }}
+    {{- $luaConfig = $luaConfig | replace "PROMETHEUS_URL" (printf "%s-prometheus.%s.svc.cluster.local" (include "supersonic.name" .) .Release.Namespace) }}
+    {{- $luaConfig = $luaConfig | replace "PROMETHEUS_SCHEME" "http" }}
+    {{- end }}
     {{ $luaConfig | indent 4 }}
 
 ---

--- a/helm/supersonic/templates/prometheus-configmap.yaml
+++ b/helm/supersonic/templates/prometheus-configmap.yaml
@@ -1,0 +1,36 @@
+{{- if not .Values.prometheus.external }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "supersonic.prometheusName" . }}-config
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ include "supersonic.name" . }}
+    app.kubernetes.io/component: prometheus
+data:
+  prometheus.yml: |
+    global:
+      scrape_interval: 5s
+      evaluation_interval: 5s
+
+    scrape_configs:
+      - job_name: 'triton'
+        static_configs:
+          - targets: ['{{ include "supersonic.tritonName" . }}:8002']
+        metrics_path: /metrics
+        relabel_configs:
+          - source_labels: [__address__]
+            target_label: instance
+            regex: '(.*)'
+            replacement: '{{ include "supersonic.name" . }}'
+
+      - job_name: 'envoy'
+        static_configs:
+          - targets: ['{{ include "supersonic.name" . }}:9901']
+        metrics_path: /stats/prometheus
+        relabel_configs:
+          - source_labels: [__address__]
+            target_label: instance
+            regex: '(.*)'
+            replacement: '{{ include "supersonic.name" . }}'
+{{- end }}

--- a/helm/supersonic/templates/prometheus-deployment.yaml
+++ b/helm/supersonic/templates/prometheus-deployment.yaml
@@ -1,0 +1,62 @@
+{{- if not .Values.prometheus.external }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "supersonic.prometheusName" . }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ include "supersonic.name" . }}
+    app.kubernetes.io/component: prometheus
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+      app.kubernetes.io/instance: {{ include "supersonic.name" . }}
+      app.kubernetes.io/component: prometheus
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+        app.kubernetes.io/instance: {{ include "supersonic.name" . }}
+        app.kubernetes.io/component: prometheus
+    spec:
+      containers:
+      - name: prometheus
+        image: prom/prometheus:v2.49.1
+        args:
+          - "--config.file=/etc/prometheus/prometheus.yml"
+          - "--storage.tsdb.path=/prometheus"
+          - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+          - "--web.console.templates=/usr/share/prometheus/consoles"
+        ports:
+          - containerPort: 9090
+            name: http
+        volumeMounts:
+          - name: prometheus-config
+            mountPath: /etc/prometheus
+          - name: prometheus-storage
+            mountPath: /prometheus
+        resources:
+          requests:
+            cpu: 500m
+            memory: 512Mi
+          limits:
+            cpu: 1
+            memory: 1Gi
+      volumes:
+        - name: prometheus-config
+          configMap:
+            name: {{ include "supersonic.prometheusName" . }}-config
+        - name: prometheus-storage
+          emptyDir: {}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      restartPolicy: Always
+{{- end }}

--- a/helm/supersonic/templates/prometheus-ingress.yaml
+++ b/helm/supersonic/templates/prometheus-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and (not .Values.prometheus.external) .Values.prometheus.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "supersonic.prometheusName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ include "supersonic.name" . }}
+    app.kubernetes.io/component: prometheus
+  annotations:
+    {{- if .Values.prometheus.ingress.annotations }}
+{{ toYaml .Values.prometheus.ingress.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  ingressClassName: {{ .Values.prometheus.ingress.ingressClassName }}
+  tls:
+  - hosts:
+      - {{ .Values.prometheus.ingress.hostName }}
+  rules:
+  - host: {{ .Values.prometheus.ingress.hostName }}
+    http:
+      paths:
+      - backend:
+          service:
+            name: {{ include "supersonic.prometheusName" . }}
+            port:
+              number: 9090
+        path: /
+        pathType: ImplementationSpecific
+{{- end }} 

--- a/helm/supersonic/templates/prometheus-service.yaml
+++ b/helm/supersonic/templates/prometheus-service.yaml
@@ -1,0 +1,21 @@
+{{- if not .Values.prometheus.external }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "supersonic.prometheusName" . }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ include "supersonic.name" . }}
+    app.kubernetes.io/component: prometheus
+spec:
+  type: ClusterIP
+  ports:
+    - port: 9090
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+    app.kubernetes.io/instance: {{ include "supersonic.name" . }}
+    app.kubernetes.io/component: prometheus
+{{- end }}

--- a/helm/supersonic/templates/so.yaml
+++ b/helm/supersonic/templates/so.yaml
@@ -2,7 +2,12 @@
 
 {{- $scaleUp := .Values.autoscaler.scaleUp | default dict }}
 {{- $scaleDown := .Values.autoscaler.scaleDown | default dict }}
-{{- $prometheusAddress := printf "%s://%s:%d" .Values.prometheus.scheme .Values.prometheus.url (int .Values.prometheus.port) | quote }}
+{{- $prometheusAddress := "" -}}
+{{- if .Values.prometheus.external -}}
+  {{- $prometheusAddress = printf "%s://%s:%d" .Values.prometheus.scheme .Values.prometheus.url (int .Values.prometheus.port) | quote -}}
+{{- else -}}
+  {{- $prometheusAddress = printf "http://%s.%s.svc.cluster.local:9090" (include "supersonic.prometheusName" .) .Release.Namespace | quote -}}
+{{- end -}}
 
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -49,6 +54,5 @@ spec:
       query: |-
         {{ include "supersonic.defaultMetric" . | nindent 8 }}
 ---
-
 
 {{- end }}

--- a/helm/supersonic/values.schema.json
+++ b/helm/supersonic/values.schema.json
@@ -396,6 +396,9 @@
     "prometheus": {
       "type": "object",
       "properties": {
+        "external": {
+          "type": "boolean"
+        },
         "url": {
           "type": "string"
         },
@@ -410,9 +413,34 @@
         },
         "serverLoadThreshold": {
           "type": "integer"
+        },
+        "ingress": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean"
+            },
+            "hostName": {
+              "type": "string"
+            },
+            "ingressClassName": {
+              "type": "string"
+            },
+            "annotations": {
+              "type": "object"
+            }
+          },
+          "required": [
+            "annotations",
+            "enabled",
+            "hostName",
+            "ingressClassName"
+          ]
         }
       },
       "required": [
+        "external",
+        "ingress",
         "port",
         "scheme",
         "serverLoadMetric",

--- a/helm/supersonic/values.yaml
+++ b/helm/supersonic/values.yaml
@@ -167,11 +167,16 @@ autoscaler:
 
 # -- Connection to a Prometheus server is required for KEDA autoscaler and Envoy's prometheus-based rate limiter
 prometheus:
-  # -- Prometheus server url and port number (find in documentation of a given cluster or ask admins)
+  # -- Whether to use external Prometheus instance (true) or deploy internal one (false)
+  external: true
+
+  # -- External Prometheus server url and port number (find in documentation of a given cluster or ask admins)
+  # Only used when external=true
   url: ""
   port: 443
 
-  # -- Specify whether Prometheus endpoint is exposed as http or https
+  # -- Specify whether external Prometheus endpoint is exposed as http or https
+  # Only used when external=true
   scheme: "https"
 
   # -- A metric used by both KEDA autoscaler and Envoy's prometheus-based rate limiter.
@@ -180,6 +185,13 @@ prometheus:
   
   # -- Threshold for the metric
   serverLoadThreshold: 100
+
+  # -- Ingress configuration for internal Prometheus web UI (only used when external=false)
+  ingress:
+    enabled: false
+    hostName: ""
+    ingressClassName: ""
+    annotations: {}
 
 ingress:
   enabled: false

--- a/values/values-cms-ci.yaml
+++ b/values/values-cms-ci.yaml
@@ -28,6 +28,8 @@ envoy:
       max_tokens: 5
       tokens_per_fill: 1
       fill_interval: 12s
+prometheus:
+  external: false
 autoscaler:
   enabled: true
   minReplicas: 1

--- a/values/values-nautilus-cms.yaml
+++ b/values/values-nautilus-cms.yaml
@@ -6,11 +6,8 @@ triton:
     - |
       /opt/tritonserver/bin/tritonserver \
       --model-repository=/cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre7/external/el9_amd64_gcc12/data/RecoBTag/Combined/data/models/ \
-      --model-repository=/cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre7/external/el9_amd64_gcc12/data/RecoEgamma/EgammaPhotonProducers/data/models/ \
-      --model-repository=/cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre7/external/el9_amd64_gcc12/data/RecoTauTag/TrainingFiles/data/DeepTauIdSONIC/ \
-      --model-repository=/cvmfs/cms.cern.ch/el9_amd64_gcc12/cms/cmssw/CMSSW_14_1_0_pre7/external/el9_amd64_gcc12/data/RecoMET/METPUSubtraction/data/models/ \
       --allow-gpu-metrics=true \
-      --log-verbose=1 \
+      --log-verbose=0 \
       --strict-model-config=false \
       --exit-timeout-secs=60 \
       --backend-config=onnxruntime,enable-global-threadpool=1
@@ -21,6 +18,7 @@ triton:
     enabled: true
     storageType: cvmfs-pvc
     mountPath: /cvmfs
+  resetReadinessProbe: true
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -29,24 +27,48 @@ triton:
               - key: nvidia.com/gpu.product
                 operator: In
                 values:
-                  - NVIDIA-A10
-                  - NVIDIA-A40
+                  # - NVIDIA-GeForce-GTX-1070
+                  # - NVIDIA-GeForce-GTX-1080
+                  # - Quadro-M4000
+                  # - NVIDIA-A100-PCIE-40GB-MIG-2g.10gb
+                  # - NVIDIA-GeForce-GTX-1080-Ti
+                  # - NVIDIA-GeForce-RTX-2080-Ti
+                  # - NVIDIA-TITAN-Xp
+                  # - Tesla-T4
+                  # - NVIDIA-A10
+                  # - NVIDIA-GeForce-RTX-3090
+                  - NVIDIA-GeForce-RTX-4090
+                  # - NVIDIA-TITAN-RTX
+                  # - NVIDIA-RTX-A5000
+                  # - Quadro-RTX-6000
+                  # - Tesla-V100-SXM2-32GB
+                  # - NVIDIA-A40
+                  # - NVIDIA-L40
+                  # - NVIDIA-RTX-A6000
+                  # - Quadro-RTX-8000
                   # - NVIDIA-A100-SXM4-80GB
-                  - NVIDIA-L40
-                  # - NVIDIA-A100-80GB-PCIe
-                  # - NVIDIA-A100-80GB-PCIe-MIG-1g.10gb
-                  - NVIDIA-L4
-                  # - NVIDIA-A100-PCIE-40GB
-                  # - NVIDIA-GH200-480GB
 envoy:
   enabled: true
 prometheus:
-  url: "prometheus.nrp-nautilus.io"
+  external: false
+  url: ""
   port: 443
   scheme: https
   serverLoadThreshold: 10
+  ingress:
+    enabled: true
+    hostName: prometheus-cms.nrp-nautilus.io
+    ingressClassName: haproxy
+    annotations:
+      haproxy-ingress.github.io/cors-enable: "true"
+      haproxy-ingress.github.io/timeout-client: "5m"
+      haproxy-ingress.github.io/timeout-server: "5m"
+      haproxy-ingress.github.io/timeout-connect: "5m"
+      haproxy-ingress.github.io/timeout-http-request: "5m"
+      haproxy-ingress.github.io/timeout-queue: "1m"
+
 autoscaler:
-  enabled: True
+  enabled: true
   minReplicas: 1
   maxReplicas: 5
 ingress:
@@ -65,3 +87,5 @@ ingress:
     haproxy-ingress.github.io/health-check-interval: "30s"
     haproxy-ingress.github.io/health-check-rise-count: "1"
 
+nodeSelector:
+  topology.kubernetes.io/zone: ucsd

--- a/values/values-nautilus-cms.yaml
+++ b/values/values-nautilus-cms.yaml
@@ -51,21 +51,11 @@ envoy:
   enabled: true
 prometheus:
   external: false
-  url: ""
-  port: 443
-  scheme: https
   serverLoadThreshold: 10
   ingress:
     enabled: true
     hostName: prometheus-cms.nrp-nautilus.io
     ingressClassName: haproxy
-    annotations:
-      haproxy-ingress.github.io/cors-enable: "true"
-      haproxy-ingress.github.io/timeout-client: "5m"
-      haproxy-ingress.github.io/timeout-server: "5m"
-      haproxy-ingress.github.io/timeout-connect: "5m"
-      haproxy-ingress.github.io/timeout-http-request: "5m"
-      haproxy-ingress.github.io/timeout-queue: "1m"
 
 autoscaler:
   enabled: true


### PR DESCRIPTION
## Add a custom Prometheus deployment option

- Add Prometheus manifests (deployment, service, configmap, ingress)
- Add `prometheusName` helper function for consistent naming
- Update Envoy and KEDA configurations to support both external and internal Prometheus

### Configuration
Controlled by `prometheus.external` value:
- When `true` (default): use external Prometheus instance specified by `prometheus.url`
- When `false`: deploy internal Prometheus:
  - Scrapes metrics from Triton and Envoy endpoints
  - 5-second scrape interval
  - Optional ingress for web UI access
  - Used by KEDA autoscaler and Envoy's Prometheus based rate limiter
