### PR TITLE
Small updates

### DIFF
--- a/helm/supersonic/templates/NOTES.txt
+++ b/helm/supersonic/templates/NOTES.txt
@@ -1,6 +1,5 @@
 ---
 {{- /* Run validation checks */ -}}
-{{- include "supersonic.validateGrafana" . -}}
 {{- include "supersonic.validateGrafanaAddressConsistency" . -}}
 {{- include "supersonic.validateGrafanaValues" . -}}
 {{- include "supersonic.validatePrometheus" . -}}

--- a/helm/supersonic/templates/_helpers/_scaling-metric.tpl
+++ b/helm/supersonic/templates/_helpers/_scaling-metric.tpl
@@ -6,11 +6,11 @@ Get default scaling metric
   {{- printf "%s" .Values.serverLoadMetric -}}
 {{- else }}
 sum by (release) (
-    rate(nv_inference_queue_duration_us{release=~"{{ include "supersonic.name" . }}"}[15s])
+    rate(nv_inference_queue_duration_us{release=~"{{ include "supersonic.name" . }}"}[30s])
 )
   /
 sum by (release) (
-    (rate(nv_inference_exec_count{release=~"{{ include "supersonic.name" . }}"}[15s]) * 1000) + 0.001
+    (rate(nv_inference_exec_count{release=~"{{ include "supersonic.name" . }}"}[30s]) * 1000) + 0.001
 )
 {{- end }}
 {{- end }}


### PR DESCRIPTION
- disable checking for duplicated Grafana deployments
- switch sampling interval from 15s to 30s in default scaling metric