### PR TITLE
More stable installation instructions & rename `autoscaler` to `keda`

### DIFF
--- a/.github/workflows/ci-full.yaml
+++ b/.github/workflows/ci-full.yaml
@@ -99,7 +99,7 @@ jobs:
       - name: Run Perf Analyzer Job
         run: |
           kubectl apply -f ci/perf-analyzer-job.yaml
-          kubectl wait --for=condition=complete job/perf-analyzer-job -n cms --timeout=180s || \
+          kubectl wait --for=condition=complete job/perf-analyzer-job -n cms --timeout=240s || \
           (echo "Perf-analyzer job did not complete in time or failed." && exit 1)
 
           POD_NAME=$(kubectl get pods -n cms -l job-name=perf-analyzer-job -o jsonpath="{.items[0].metadata.name}")

--- a/.github/workflows/ci-installation.yaml
+++ b/.github/workflows/ci-installation.yaml
@@ -29,20 +29,6 @@ jobs:
         run: |
           kubectl create namespace test-ns
 
-      - name: Install Prometheus Operator CRDs
-        run: |
-          helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
-          helm repo update
-          kubectl create namespace monitoring
-          helm install prometheus-operator prometheus-community/kube-prometheus-stack --namespace monitoring --set prometheusOperator.createCustomResource=false --set defaultRules.create=false --set alertmanager.enabled=false --set prometheus.enabled=false --set grafana.enabled=false
-
-      - name: Install KEDA Autoscaler CRDs
-        run: |
-          helm repo add kedacore https://kedacore.github.io/charts
-          helm repo update
-          kubectl create namespace keda
-          helm install keda kedacore/keda --namespace keda  
-
       - name: Test installation of SuperSONIC from remote repo via plugin
         run: |
           helm repo add fastml https://fastmachinelearning.org/SuperSONIC/

--- a/.github/workflows/ci-installation.yaml
+++ b/.github/workflows/ci-installation.yaml
@@ -29,12 +29,12 @@ jobs:
         run: |
           kubectl create namespace test-ns
 
-      - name: Test installation of SuperSONIC from remote repo via plugin
-        run: |
-          helm repo add fastml https://fastmachinelearning.org/SuperSONIC/
-          helm repo update
-          helm install supersonic fastml/supersonic -n test-ns -f values/values-minimal.yaml
-          helm uninstall supersonic -n test-ns
+      # - name: Test installation of SuperSONIC from remote repo 
+      #   run: |
+      #     helm repo add fastml https://fastmachinelearning.org/SuperSONIC/
+      #     helm repo update
+      #     helm install supersonic fastml/supersonic -n test-ns -f values/values-minimal.yaml
+      #     helm uninstall supersonic -n test-ns
 
       - name: Test installation of SuperSONIC from GitHub
         run: |

--- a/.github/workflows/ci-installation.yaml
+++ b/.github/workflows/ci-installation.yaml
@@ -29,6 +29,7 @@ jobs:
         run: |
           kubectl create namespace test-ns
 
+      # WARNING:This test is disabled until a compatible SuperSONIC version is released
       # - name: Test installation of SuperSONIC from remote repo 
       #   run: |
       #     helm repo add fastml https://fastmachinelearning.org/SuperSONIC/

--- a/docs/.values-table.md
+++ b/docs/.values-table.md
@@ -50,16 +50,16 @@
 | envoy.auth.url | string | `""` |  |
 | envoy.auth.port | int | `443` |  |
 | envoy.tracing_sampling_rate | float | `0.01` |  |
-| autoscaler.enabled | bool | `false` | Enable autoscaling (requires Prometheus to also be enabled). Autoscaling will be based on the metric is taken from parameter ``prometheus.serverLoadMetric``, new Triton servers will spawn if the metric exceedds the threshold set by ``prometheus.serverLoadThreshold``. |
-| autoscaler.minReplicaCount | int | `1` | Minimum and maximum number of Triton servers. Warning: if min=0 and desired Prometheus metric is empty, the first server will never start |
-| autoscaler.maxReplicaCount | int | `2` |  |
-| autoscaler.zeroIdleReplicas | bool | `false` | If set to true, the server will release all GPUs when idle. Be careful: if the scaling metric is extracted from Triton servers, it will be unavailable, and scaling from 0 to 1 will never happen. |
-| autoscaler.scaleUp.stabilizationWindowSeconds | int | `60` |  |
-| autoscaler.scaleUp.periodSeconds | int | `60` |  |
-| autoscaler.scaleUp.stepsize | int | `1` |  |
-| autoscaler.scaleDown.stabilizationWindowSeconds | int | `600` |  |
-| autoscaler.scaleDown.periodSeconds | int | `120` |  |
-| autoscaler.scaleDown.stepsize | int | `1` |  |
+| keda.enabled | bool | `false` | Enable autoscaling (requires Prometheus to also be enabled). Autoscaling will be based on the metric is taken from parameter ``prometheus.serverLoadMetric``, new Triton servers will spawn if the metric exceedds the threshold set by ``prometheus.serverLoadThreshold``. |
+| keda.minReplicaCount | int | `1` | Minimum and maximum number of Triton servers. Warning: if min=0 and desired Prometheus metric is empty, the first server will never start |
+| keda.maxReplicaCount | int | `2` |  |
+| keda.zeroIdleReplicas | bool | `false` | If set to true, the server will release all GPUs when idle. Be careful: if the scaling metric is extracted from Triton servers, it will be unavailable, and scaling from 0 to 1 will never happen. |
+| keda.scaleUp.stabilizationWindowSeconds | int | `60` |  |
+| keda.scaleUp.periodSeconds | int | `60` |  |
+| keda.scaleUp.stepsize | int | `1` |  |
+| keda.scaleDown.stabilizationWindowSeconds | int | `600` |  |
+| keda.scaleDown.periodSeconds | int | `120` |  |
+| keda.scaleDown.stepsize | int | `1` |  |
 | prometheus.external.enabled | bool | `false` | Enable external Prometheus instance. If true, Prometheus parameters outside of prometheus.external will be ignored. |
 | prometheus.external.url | string | `""` | External Prometheus server url |
 | prometheus.external.port | int | `443` | External Prometheus server port number |

--- a/docs/configuration-guide.rst
+++ b/docs/configuration-guide.rst
@@ -324,21 +324,21 @@ Grafana Ingress for web access, and datasources to connect to Prometheus,
 ==========================================
 
 Autoscaling is implemented via `KEDA (Kubernetes Event-Driven Autoscaler) <https://keda.sh/>`_ and
-can be enabled via the ``autoscaler.enabled`` parameter in the values file.
+can be enabled via the ``keda.enabled`` parameter in the values file.
 
 .. warning::
 
    Deploying KEDA autoscaler requires KEDA CustomResourceDefinitions to be installed in the cluster.
    Please contact cluster administrators if this step of installation fails.
 
-The parameters ``autoscaler.minReplicaCount`` and ``autoscaler.maxReplicaCount`` define the range in which
+The parameters ``keda.minReplicaCount`` and ``keda.maxReplicaCount`` define the range in which
 the number of Triton servers can scale.
 
 Additional optional parameters can control how quickly the autoscaler reacts to changes in the Prometheus metric:
 
 .. code-block:: yaml
 
-   autoscaler:
+   keda:
      enabled: true
 
      minReplicaCount: 1

--- a/helm/supersonic/templates/keda/so.yaml
+++ b/helm/supersonic/templates/keda/so.yaml
@@ -1,7 +1,7 @@
-{{- if .Values.autoscaler.enabled }}
+{{- if .Values.keda.enabled }}
 
-{{- $scaleUp := .Values.autoscaler.scaleUp | default dict }}
-{{- $scaleDown := .Values.autoscaler.scaleDown | default dict }}
+{{- $scaleUp := .Values.keda.scaleUp | default dict }}
+{{- $scaleDown := .Values.keda.scaleDown | default dict }}
 
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -17,11 +17,11 @@ spec:
     kind: Deployment
   pollingInterval: 30
   cooldownPeriod: 120
-{{- if (eq .Values.autoscaler.zeroIdleReplicas true) }}
+{{- if (eq .Values.keda.zeroIdleReplicas true) }}
   idleReplicaCount: 0
 {{- end }}
-  minReplicaCount: {{ default 1 .Values.autoscaler.minReplicaCount }}
-  maxReplicaCount: {{ default 14 .Values.autoscaler.maxReplicaCount }}
+  minReplicaCount: {{ default 1 .Values.keda.minReplicaCount }}
+  maxReplicaCount: {{ default 14 .Values.keda.maxReplicaCount }}
   advanced:
     horizontalPodAutoscalerConfig:
       behavior:

--- a/helm/supersonic/templates/monitoring/servicemonitor.yaml
+++ b/helm/supersonic/templates/monitoring/servicemonitor.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.prometheus.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
@@ -57,3 +58,4 @@ spec:
         targetLabel: app
         regex: "(.*)"
         replacement: "{{ .Chart.Name }}"
+{{- end }}

--- a/helm/supersonic/values.schema.json
+++ b/helm/supersonic/values.schema.json
@@ -463,7 +463,7 @@
         "tracing_sampling_rate"
       ]
     },
-    "autoscaler": {
+    "keda": {
       "type": "object",
       "properties": {
         "enabled": {
@@ -1955,9 +1955,9 @@
     }
   },
   "required": [
-    "autoscaler",
     "envoy",
     "grafana",
+    "keda",
     "metricsCollector",
     "nameOverride",
     "opentelemetry-collector",

--- a/helm/supersonic/values.yaml
+++ b/helm/supersonic/values.yaml
@@ -199,7 +199,7 @@ envoy:
   
   tracing_sampling_rate: 0.01 # must be 1 / triton sampling rate
 
-autoscaler:
+keda:
 
   # -- Enable autoscaling (requires Prometheus to also be enabled).
   # Autoscaling will be based on the metric is taken from parameter ``prometheus.serverLoadMetric``,

--- a/values/values-anvil-cms.yaml
+++ b/values/values-anvil-cms.yaml
@@ -37,7 +37,7 @@ envoy:
     enabled: true
     hostName: sonic-cms.anvilcloud.rcac.purdue.edu
 
-autoscaler:
+keda:
   enabled: false
   minReplicaCount: 1
   maxReplicaCount: 5

--- a/values/values-geddes-cms.yaml
+++ b/values/values-geddes-cms.yaml
@@ -57,7 +57,7 @@ envoy:
     hostName: sonic-cms.geddes.rcac.purdue.edu
     ingressClassName: public
 
-autoscaler:
+keda:
   enabled: true
   minReplicaCount: 1
   maxReplicaCount: 7

--- a/values/values-minimal-full.yaml
+++ b/values/values-minimal-full.yaml
@@ -34,7 +34,7 @@ envoy:
       tokens_per_fill: 1
       fill_interval: 12s
 
-autoscaler:
+keda:
   enabled: true
   minReplicaCount: 1
   maxReplicaCount: 2

--- a/values/values-minimal.yaml
+++ b/values/values-minimal.yaml
@@ -16,8 +16,6 @@ triton:
     enabled: true
     storageType: cvmfs-pvc
     mountPath: /cvmfs
-  readinessProbe:
-    reset: true
 
 envoy:
   enabled: true

--- a/values/values-nautilus-atlas.yaml
+++ b/values/values-nautilus-atlas.yaml
@@ -55,7 +55,7 @@ envoy:
       haproxy-ingress.github.io/health-check-interval: "30s"
       haproxy-ingress.github.io/health-check-rise-count: "1"
 
-autoscaler:
+keda:
   enabled: False
   minReplicaCount: 0
   maxReplicaCount: 1

--- a/values/values-nautilus-cms.yaml
+++ b/values/values-nautilus-cms.yaml
@@ -69,7 +69,7 @@ envoy:
       haproxy-ingress.github.io/health-check-rise-count: "1"
   tracing_sampling_rate: 0.001
 
-autoscaler:
+keda:
   enabled: false
   minReplicaCount: 1
   maxReplicaCount: 100

--- a/values/values-nautilus-icecube.yaml
+++ b/values/values-nautilus-icecube.yaml
@@ -73,7 +73,7 @@ envoy:
       haproxy-ingress.github.io/health-check-interval: "30s"
       haproxy-ingress.github.io/health-check-rise-count: "1"
 
-autoscaler:
+keda:
   enabled: false
   minReplicaCount: 0
   maxReplicaCount: 1


### PR DESCRIPTION
- making sure that minimal installation instructions do not require extra CRDs
- change `autoscaler` parameters to `keda` for more clarity