### PR TITLE
Update default Triton image versions

### DIFF
--- a/docs/.values-table.md
+++ b/docs/.values-table.md
@@ -6,7 +6,7 @@
 | serverLoadMetric | string | `""` | A metric used by both KEDA autoscaler and Envoy's prometheus-based rate limiter. # Default metric (inference queue latency) is defined in templates/_helpers.tpl |
 | serverLoadThreshold | int | `100` | Threshold for the metric |
 | triton.replicas | int | `1` | Number of Triton server instances (if autoscaling is disabled) |
-| triton.image | string | `"nvcr.io/nvidia/tritonserver:24.12-py3-min"` | Docker image for the Triton server |
+| triton.image | string | `"nvcr.io/nvidia/tritonserver:26.04-py3-min"` | Docker image for the Triton server |
 | triton.command | list | `["/bin/sh","-c"]` | Command and arguments to run in Triton container |
 | triton.args[0] | string | `"/opt/tritonserver/bin/tritonserver \\\n--model-repository=/tmp/ \\\n--log-verbose=0 \\\n--exit-timeout-secs=60\n"` |  |
 | triton.resources | object | `{"limits":{"cpu":1,"memory":"2G"},"requests":{"cpu":1,"memory":"2G"}}` | Resource limits and requests for each Triton instance. You can add necessary GPU request here. |

--- a/helm/supersonic/values.yaml
+++ b/helm/supersonic/values.yaml
@@ -15,7 +15,7 @@ triton:
   replicas: 1
 
   # -- Docker image for the Triton server
-  image: "nvcr.io/nvidia/tritonserver:24.12-py3-min"
+  image: "nvcr.io/nvidia/tritonserver:26.04-py3-min"
   
   # -- Command and arguments to run in Triton container
   command: ["/bin/sh", "-c"]

--- a/tests/perf-analyzer-job-ci.yaml
+++ b/tests/perf-analyzer-job-ci.yaml
@@ -10,7 +10,7 @@ spec:
       restartPolicy: Never
       containers:
       - name: perf-analyzer
-        image: nvcr.io/nvidia/tritonserver:22.07-py3-sdk
+        image: nvcr.io/nvidia/tritonserver:26.04-py3-sdk
         command: ["/bin/bash"]
         args:
           - "-c"

--- a/tests/perf-analyzer-job.yaml
+++ b/tests/perf-analyzer-job.yaml
@@ -12,7 +12,7 @@ spec:
       restartPolicy: OnFailure
       containers:
       - name: perf-analyzer
-        image: nvcr.io/nvidia/tritonserver:24.11-py3-sdk
+        image: nvcr.io/nvidia/tritonserver:26.04-py3-sdk
         command: ["/bin/bash"]
         args:
           - "-c"

--- a/tests/values-external-envoy-config.yaml
+++ b/tests/values-external-envoy-config.yaml
@@ -2,7 +2,7 @@
 
 triton:
   replicas: 1
-  image: fastml/triton-torchgeo:22.07-py3-geometric # works for CMSSW run3
+  image: fastml/triton-torchgeo:26.04-py3-geometric # works for CMSSW run3
   command: ["/bin/sh", "-c"]
   args: 
     - |

--- a/values/values-anvil-cms.yaml
+++ b/values/values-anvil-cms.yaml
@@ -1,5 +1,5 @@
 triton:
-  image: nvcr.io/nvidia/tritonserver:24.11-py3
+  image: nvcr.io/nvidia/tritonserver:26.04-py3
   command: ["/bin/sh", "-c"]
   args: 
     - |

--- a/values/values-geddes-cms.yaml
+++ b/values/values-geddes-cms.yaml
@@ -2,7 +2,7 @@ serverLoadThreshold: 20
 serverLoadMetric: 'sum by (release) (rate(nv_inference_queue_duration_us{release=~"sonic-server"}[30s]) / (rate(nv_inference_exec_count{release=~"sonic-server"}[30s]) * 1000 + 0.001))'
 
 triton:
-  image: nvcr.io/nvidia/tritonserver:24.11-py3
+  image: nvcr.io/nvidia/tritonserver:26.04-py3
   command: ["/bin/sh", "-c"]
   args:
     - |

--- a/values/values-minimal-full.yaml
+++ b/values/values-minimal-full.yaml
@@ -1,6 +1,6 @@
 triton:
   replicas: 1
-  image: fastml/triton-torchgeo:22.07-py3-geometric # works for CMSSW run3
+  image: fastml/triton-torchgeo:26.04-py3-geometric # works for CMSSW run3
   command: ["/bin/sh", "-c"]
   args: 
     - |

--- a/values/values-minimal.yaml
+++ b/values/values-minimal.yaml
@@ -1,6 +1,6 @@
 triton:
   replicas: 1
-  image: fastml/triton-torchgeo:22.07-py3-geometric # works for CMSSW run3
+  image: fastml/triton-torchgeo:26.04-py3-geometric # works for CMSSW run3
   command: ["/bin/sh", "-c"]
   args: 
     - |

--- a/values/values-nautilus-cms.yaml
+++ b/values/values-nautilus-cms.yaml
@@ -4,7 +4,7 @@ triton:
   replicas: 5
   # image: fastml/triton-torchgeo:21.02-py3-geometric # run2
   # image: fastml/triton-torchgeo:22.07-py3-geometric # run3
-  image: nvcr.io/nvidia/tritonserver:24.11-py3
+  image: nvcr.io/nvidia/tritonserver:26.04-py3
   # image: yongbinfeng/tritonserver:rhel8.9_v3
   # image: gitlab-registry.nrp-nautilus.io/kondratyevd/supersonic/triton-torchgeo:22.07-py3-geometric
   command: ["/bin/sh", "-c"]

--- a/values/values-nautilus-icecube.yaml
+++ b/values/values-nautilus-icecube.yaml
@@ -1,7 +1,7 @@
 serverLoadThreshold: 100
 
 triton: 
-  image: nvcr.io/nvidia/tritonserver:24.10-py3
+  image: nvcr.io/nvidia/tritonserver:26.04-py3
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
Updating all default Triton versions to 26.04 to address [recent CVEs](https://nvidia.custhelp.com/app/answers/detail/a_id/5828).